### PR TITLE
Fix the compile args order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,3 +19,8 @@ scripts:
   - cd ../../KAEzip
   - sudo bash setup.sh install
   
+  - cd test
+  - make
+  - export LD_LIBRARY_PATH=/usr/local/kaezip/lib
+  - ./kaezip_perf -m 8 -l 1024 -n 1000
+  - ./kaezip_perf -m 8 -l 1024 -n 1000 -d

--- a/test/makefile
+++ b/test/makefile
@@ -4,14 +4,15 @@ INCDIR += -I /usr/local/kaezip/include/
 LIBDIR := -L/usr/local/kaezip/lib
 
 # The flags
-CFLAGS    := -g -lz -Wall
+LIBFLAGS  := -lz
+CFLAGS    := -g -Wall
 LDFLAGS   := $(LIBDIR)
 
 all: kaezip_perf
 objects = kaezip_perf.c
 
 kaezip_perf : $(objects)
-	gcc $(CFLAGS) $(LDFLAGS) $(INCDIR) -o kaezip_perf $(objects)
+	gcc $(CFLAGS) $(LDFLAGS) $(INCDIR) -o kaezip_perf $(objects) $(LIBFLAGS)
 
 .PHONY : clean
 clean :


### PR DESCRIPTION
This patch fixes the compile args order to avoid build error in some OS like ubuntu 18.04.

Related: https://github.com/kunpengcompute/KAEzip/issues/9