### PR TITLE
Add deflate reset

### DIFF
--- a/patch/kaezip_for_zlib-1.2.11.patch
+++ b/patch/kaezip_for_zlib-1.2.11.patch
@@ -15,7 +15,7 @@ diff -Naru zlib-1.2.11/compress.c zlib-1.2.11_new/compress.c
  }
 diff -Naru zlib-1.2.11/deflate.c zlib-1.2.11_new/deflate.c
 --- zlib-1.2.11/deflate.c	2017-01-16 01:29:40.000000000 +0800
-+++ zlib-1.2.11_new/deflate.c	2020-06-06 18:50:13.708435700 +0800
++++ zlib-1.2.11_new/deflate.c	2020-09-11 08:50:22.000000000 +0800
 @@ -50,6 +50,7 @@
  /* @(#) $Id$ */
  
@@ -35,11 +35,14 @@ diff -Naru zlib-1.2.11/deflate.c zlib-1.2.11_new/deflate.c
                    version, stream_size)
      z_streamp strm;
      int  level;
-@@ -346,6 +348,28 @@
+@@ -344,7 +346,29 @@
+     s->strategy = strategy;
+     s->method = (Byte)method;
  
-     return deflateReset(strm);
- }
-+	
+-    return deflateReset(strm);
++    return lz_deflateReset(strm);
++}
++
 +int ZEXPORT deflateInit2_(strm, level, method, windowBits, memLevel, strategy,
 +                  version, stream_size)
 +    z_streamp strm;
@@ -60,11 +63,38 @@ diff -Naru zlib-1.2.11/deflate.c zlib-1.2.11_new/deflate.c
 +
 +    return lz_deflateInit2_(strm, level, method, windowBits, memLevel, strategy,
 +                version, stream_size);
-+}
+ }
  
  /* =========================================================================
-  * Check for a valid deflate stream state. Return 0 if ok, 1 if not.
-@@ -653,6 +677,17 @@
+@@ -502,7 +526,7 @@
+ }
+
+ /* ========================================================================= */
+-int ZEXPORT deflateReset (strm)
++int ZEXPORT lz_deflateReset (strm)
+     z_streamp strm;
+ {
+     int ret;
+@@ -513,6 +537,18 @@
+     return ret;
+ }
+
++int ZEXPORT deflateReset(strm)
++z_streamp strm;
++{
++#ifdef CONF_KAEZIP
++    if (kz_get_devices()) {
++        return kz_deflateReset(strm);
++    }
++#endif
++
++    return lz_deflateReset(strm);
++}
++
+ /* ========================================================================= */
+ int ZEXPORT deflateSetHeader (strm, head)
+     z_streamp strm;
+@@ -653,6 +689,17 @@
      z_streamp strm;
      uLong sourceLen;
  {
@@ -82,7 +112,7 @@ diff -Naru zlib-1.2.11/deflate.c zlib-1.2.11_new/deflate.c
      deflate_state *s;
      uLong complen, wraplen;
  
-@@ -760,7 +795,8 @@
+@@ -760,7 +807,8 @@
      } while (0)
  
  /* ========================================================================= */
@@ -92,7 +122,7 @@ diff -Naru zlib-1.2.11/deflate.c zlib-1.2.11_new/deflate.c
      z_streamp strm;
      int flush;
  {
-@@ -1072,10 +1108,29 @@
+@@ -1072,10 +1120,29 @@
      return s->pending != 0 ? Z_OK : Z_STREAM_END;
  }
  
@@ -123,7 +153,7 @@ diff -Naru zlib-1.2.11/deflate.c zlib-1.2.11_new/deflate.c
      int status;
  
      if (deflateStateCheck(strm)) return Z_STREAM_ERROR;
-@@ -1091,9 +1146,22 @@
+@@ -1091,9 +1158,22 @@
      ZFREE(strm, strm->state);
      strm->state = Z_NULL;
  

--- a/src/kaezip_deflate.c
+++ b/src/kaezip_deflate.c
@@ -176,6 +176,17 @@ static void kaezip_deflate_set_fmt_header(z_streamp strm, int comp_alg_type)
     kaezip_ctx->header_pos = fmt_header_sz;
 }
 
+int ZEXPORT kz_deflateReset(z_streamp strm)
+{
+    kaezip_ctx_t *kaezip_ctx = (kaezip_ctx_t *)strm->reserved;
+    if (kaezip_ctx != NULL) {
+        US_DEBUG("kaezip deflate reset");
+        kaezip_init_ctx(kaezip_ctx);
+    }
+
+    return lz_deflateReset(strm);
+}
+
 static int kaezip_do_deflate(z_streamp strm, int flush)
 {
     kaezip_ctx_t *kaezip_ctx = (kaezip_ctx_t *)strm->reserved;

--- a/src/kaezip_deflate.h
+++ b/src/kaezip_deflate.h
@@ -27,10 +27,12 @@ extern int kz_deflateInit2_(z_streamp strm, int level, int metho, int windowBit,
                       const char *version, int stream_size);
 extern int kz_deflate(z_streamp strm, int flush);
 extern int kz_deflateEnd(z_streamp strm);
+extern int kz_deflateReset(z_streamp strm);
 
 extern int lz_deflateEnd(z_streamp strm);
 extern int lz_deflateInit2_(z_streamp strm, int level, int metho, int windowBit, int memLevel, int strategy,
                       const char *version, int stream_size);
+extern int lz_deflateReset(z_streamp strm);
 
 #endif
 


### PR DESCRIPTION
This patch adds the deflate reset method in KAEZip to make the kaecontext re-init after inflated reset call. 

Close: https://github.com/kunpengcompute/KAEzip/issues/12