### PR TITLE
Fix deflate reset issue and support inflate with windowsBits 47

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ENGINE_INSTALL_PATH := /usr/local/kaezip
 CC=gcc
 
 LIBNAME := libkaezip.so
-VERSION = 1.3.8
+VERSION = 1.3.9
 TARGET = ${LIBNAME}.${VERSION}
 SOFTLINK = libkaezip.so
 

--- a/include/kaezip.h
+++ b/include/kaezip.h
@@ -33,14 +33,23 @@ extern int kz_deflateInit2_(z_streamp strm, int level, int metho, int windowBit,
 extern int kz_inflateInit2_(z_streamp strm, int windowBits, const char *version, int stream_size);
 extern int kz_deflateEnd(z_streamp strm);
 extern int kz_inflateReset(z_streamp strm);
+extern int Kz_deflateReset(z_streamp strm);
+extern int kz_getAutoInflateAlgType(z_streamp strm);
+extern int kz_do_inflateInit(z_streamp strm, int alg_comp_type);
 
 extern int lz_deflateEnd(z_streamp strm);
 extern int lz_deflateInit2_(z_streamp strm, int level, int metho, int windowBit, int memLevel, int strategy,
                       const char *version, int stream_size);
+extern int lz_deflateReset(z_streamp strm);
 
 extern int lz_inflateEnd(z_streamp strm);
 extern int lz_inflateInit2_(z_streamp strm, int windowBits, const char *version, int stream_size);
 extern int lz_inflateReset(z_streamp strm);
 
+extern int getInflateStateWrap(z_streamp strm);
+extern unsigned long getInflateKaezipCtx(z_streamp strm);
+extern void setInflateKaezipCtx(z_streamp strm, unsigned long kaezip_ctx);
+extern unsigned long getDeflateKaezipCtx(z_streamp strm);
+extern void setDeflateKaezipCtx(z_streamp strm, unsigned long kaezip_ctx);
 #endif
 

--- a/kaezip.spec
+++ b/kaezip.spec
@@ -1,6 +1,6 @@
 Name:          libkaezip
 Summary:       Huawei Kunpeng Accelerator Engine Zip
-Version:       1.3.8
+Version:       1.3.9
 Release:       1%dist
 License:       Apache-2.0
 Source:        %{name}-%{version}.tar.gz

--- a/patch/kaezip_for_zlib-1.2.11.patch
+++ b/patch/kaezip_for_zlib-1.2.11.patch
@@ -1,6 +1,6 @@
-diff -Naru zlib-1.2.11/compress.c zlib-1.2.11_new/compress.c
+diff -Naru zlib-1.2.11/compress.c ./zlib-1.2.11_new/compress.c
 --- zlib-1.2.11/compress.c	2017-01-01 15:37:10.000000000 +0800
-+++ zlib-1.2.11_new/compress.c	2020-06-06 18:52:33.858867300 +0800
++++ ./zlib-1.2.11_new/compress.c	2020-09-17 11:38:29.404655410 +0800
 @@ -81,6 +81,10 @@
  uLong ZEXPORT compressBound (sourceLen)
      uLong sourceLen;
@@ -13,9 +13,9 @@ diff -Naru zlib-1.2.11/compress.c zlib-1.2.11_new/compress.c
 +        (sourceLen >> 25) + 13;
 +#endif
  }
-diff -Naru zlib-1.2.11/deflate.c zlib-1.2.11_new/deflate.c
+diff -Naru zlib-1.2.11/deflate.c ./zlib-1.2.11_new/deflate.c
 --- zlib-1.2.11/deflate.c	2017-01-16 01:29:40.000000000 +0800
-+++ zlib-1.2.11_new/deflate.c	2020-06-06 18:50:13.708435700 +0800
++++ ./zlib-1.2.11_new/deflate.c	2020-09-17 11:41:29.454655410 +0800
 @@ -50,6 +50,7 @@
  /* @(#) $Id$ */
  
@@ -35,10 +35,13 @@ diff -Naru zlib-1.2.11/deflate.c zlib-1.2.11_new/deflate.c
                    version, stream_size)
      z_streamp strm;
      int  level;
-@@ -346,6 +348,28 @@
+@@ -344,7 +346,29 @@
+     s->strategy = strategy;
+     s->method = (Byte)method;
  
-     return deflateReset(strm);
- }
+-    return deflateReset(strm);
++    return lz_deflateReset(strm);
++}
 +	
 +int ZEXPORT deflateInit2_(strm, level, method, windowBits, memLevel, strategy,
 +                  version, stream_size)
@@ -60,11 +63,38 @@ diff -Naru zlib-1.2.11/deflate.c zlib-1.2.11_new/deflate.c
 +
 +    return lz_deflateInit2_(strm, level, method, windowBits, memLevel, strategy,
 +                version, stream_size);
-+}
+ }
  
  /* =========================================================================
-  * Check for a valid deflate stream state. Return 0 if ok, 1 if not.
-@@ -653,6 +677,17 @@
+@@ -502,7 +526,7 @@
+ }
+ 
+ /* ========================================================================= */
+-int ZEXPORT deflateReset (strm)
++int ZEXPORT lz_deflateReset (strm)
+     z_streamp strm;
+ {
+     int ret;
+@@ -513,6 +537,18 @@
+     return ret;
+ }
+ 
++int ZEXPORT deflateReset(strm)
++z_streamp strm;
++{
++#ifdef CONF_KAEZIP
++    if (kz_get_devices()) {
++        return kz_deflateReset(strm);       
++    }
++#endif
++
++    return lz_deflateReset(strm);
++}
++
+ /* ========================================================================= */
+ int ZEXPORT deflateSetHeader (strm, head)
+     z_streamp strm;
+@@ -653,6 +689,17 @@
      z_streamp strm;
      uLong sourceLen;
  {
@@ -82,7 +112,7 @@ diff -Naru zlib-1.2.11/deflate.c zlib-1.2.11_new/deflate.c
      deflate_state *s;
      uLong complen, wraplen;
  
-@@ -760,7 +795,8 @@
+@@ -760,7 +807,8 @@
      } while (0)
  
  /* ========================================================================= */
@@ -92,7 +122,7 @@ diff -Naru zlib-1.2.11/deflate.c zlib-1.2.11_new/deflate.c
      z_streamp strm;
      int flush;
  {
-@@ -1072,10 +1108,29 @@
+@@ -1072,10 +1120,30 @@
      return s->pending != 0 ? Z_OK : Z_STREAM_END;
  }
  
@@ -102,7 +132,8 @@ diff -Naru zlib-1.2.11/deflate.c zlib-1.2.11_new/deflate.c
 +{
 +#ifdef CONF_KAEZIP
 +    if (kz_get_devices()) {
-+        if (strm->reserved != 0 && flush != Z_PARTIAL_FLUSH && flush != Z_TREES) {
++        unsigned long kaezip_ctx = getDeflateKaezipCtx(strm);
++        if (kaezip_ctx != 0 && flush != Z_PARTIAL_FLUSH && flush != Z_TREES) {
 +            return kz_deflate(strm, flush);
 +        } else {
 +            return lz_deflate(strm, flush);
@@ -123,7 +154,7 @@ diff -Naru zlib-1.2.11/deflate.c zlib-1.2.11_new/deflate.c
      int status;
  
      if (deflateStateCheck(strm)) return Z_STREAM_ERROR;
-@@ -1091,9 +1146,22 @@
+@@ -1091,9 +1159,22 @@
      ZFREE(strm, strm->state);
      strm->state = Z_NULL;
  
@@ -146,9 +177,58 @@ diff -Naru zlib-1.2.11/deflate.c zlib-1.2.11_new/deflate.c
  /* =========================================================================
   * Copy the source state to the destination state.
   * To simplify the source, this is not supported for 16-bit MSDOS (which
-diff -Naru zlib-1.2.11/inflate.c zlib-1.2.11_new/inflate.c
+@@ -2161,3 +2242,36 @@
+         FLUSH_BLOCK(s, 0);
+     return block_done;
+ }
++    
++unsigned long getDeflateKaezipCtx(z_streamp strm)
++{
++    deflate_state *state;
++  
++    if (strm == Z_NULL) {
++        return (unsigned long)0;
++    }
++    state = (deflate_state *)strm->state;
++    if (state == Z_NULL) {
++        return (unsigned long)0;
++    }
++    state = (deflate_state *)strm->state;
++
++    return state->kaezip_ctx;
++}
++
++void setDeflateKaezipCtx(z_streamp strm, unsigned long kaezip_ctx)
++{
++    deflate_state *state;
++ 
++    if (strm == Z_NULL) {
++        return;
++    }
++    state = (deflate_state *)strm->state;
++    if (state == Z_NULL) {
++        return;
++    }
++
++    state->kaezip_ctx = kaezip_ctx;
++    return;
++}
++
+diff -Naru zlib-1.2.11/deflate.h ./zlib-1.2.11_new/deflate.h
+--- zlib-1.2.11/deflate.h	2017-01-01 15:37:10.000000000 +0800
++++ ./zlib-1.2.11_new/deflate.h	2020-09-17 11:41:29.494655410 +0800
+@@ -272,7 +272,7 @@
+      * longest match routines access bytes past the input.  This is then
+      * updated to the new high water mark.
+      */
+-
++    ulg kaezip_ctx; /* kunpeng kaezip context */    
+ } FAR deflate_state;
+ 
+ /* Output a byte on the stream.
+diff -Naru zlib-1.2.11/inflate.c ./zlib-1.2.11_new/inflate.c
 --- zlib-1.2.11/inflate.c	2017-01-01 15:37:10.000000000 +0800
-+++ zlib-1.2.11_new/inflate.c	2020-06-06 18:50:13.714419100 +0800
++++ ./zlib-1.2.11_new/inflate.c	2020-09-17 11:41:29.434655410 +0800
 @@ -84,6 +84,7 @@
  #include "inftrees.h"
  #include "inflate.h"
@@ -230,7 +310,7 @@ diff -Naru zlib-1.2.11/inflate.c zlib-1.2.11_new/inflate.c
  z_streamp strm;
  int flush;
  {
-@@ -1273,8 +1302,25 @@
+@@ -1273,8 +1302,30 @@
          ret = Z_BUF_ERROR;
      return ret;
  }
@@ -239,8 +319,13 @@ diff -Naru zlib-1.2.11/inflate.c zlib-1.2.11_new/inflate.c
 +int flush;
 +{
 +#ifdef CONF_KAEZIP
++    int alg_type;
++    unsigned long kaezip_ctx;
 +    if (kz_get_devices()) {
-+        if (strm->reserved != 0 && flush != Z_PARTIAL_FLUSH 
++        alg_type = kz_getAutoInflateAlgType(strm);
++        (void)kz_do_inflateInit(strm, alg_type);
++        kaezip_ctx = getInflateKaezipCtx(strm);
++        if (kaezip_ctx != 0 && flush != Z_PARTIAL_FLUSH 
 +            && flush != Z_TREES) {
 +            return kz_inflate(strm, flush);
 +        } else {
@@ -257,7 +342,7 @@ diff -Naru zlib-1.2.11/inflate.c zlib-1.2.11_new/inflate.c
  z_streamp strm;
  {
      struct inflate_state FAR *state;
-@@ -1285,9 +1331,22 @@
+@@ -1285,9 +1336,22 @@
      ZFREE(strm, strm->state);
      strm->state = Z_NULL;
      Tracev((stderr, "inflate: end\n"));
@@ -280,7 +365,7 @@ diff -Naru zlib-1.2.11/inflate.c zlib-1.2.11_new/inflate.c
  int ZEXPORT inflateGetDictionary(strm, dictionary, dictLength)
  z_streamp strm;
  Bytef *dictionary;
-@@ -1397,6 +1456,7 @@
+@@ -1397,6 +1461,7 @@
      return next;
  }
  
@@ -288,7 +373,7 @@ diff -Naru zlib-1.2.11/inflate.c zlib-1.2.11_new/inflate.c
  int ZEXPORT inflateSync(strm)
  z_streamp strm;
  {
-@@ -1434,7 +1494,7 @@
+@@ -1434,7 +1499,7 @@
      /* return no joy or set up to restart inflate() on a new block */
      if (state->have != 4) return Z_DATA_ERROR;
      in = strm->total_in;  out = strm->total_out;
@@ -297,9 +382,72 @@ diff -Naru zlib-1.2.11/inflate.c zlib-1.2.11_new/inflate.c
      strm->total_in = in;  strm->total_out = out;
      state->mode = TYPE;
      return Z_OK;
-diff -Naru zlib-1.2.11/Makefile.in zlib-1.2.11_new/Makefile.in
+@@ -1559,3 +1624,53 @@
+     state = (struct inflate_state FAR *)strm->state;
+     return (unsigned long)(state->next - state->codes);
+ }
++
++int getInflateStateWrap(z_streamp strm)
++{
++    struct inflate_state FAR *state;
++    
++    if (strm == Z_NULL) {
++        return 0;
++    }
++    state = (struct inflate_state FAR *)strm->state;
++
++    if (state == Z_NULL) {
++        return 0;
++    }
++
++    return state->wrap;
++}
++
++unsigned long getInflateKaezipCtx(z_streamp strm)
++{
++    struct inflate_state FAR *state;
++    
++    if (strm == Z_NULL) {
++        return (unsigned long)0;
++    }
++    
++    state = (struct inflate_state FAR *)strm->state;
++    if (state == Z_NULL) {
++        return (unsigned long)0;
++    }
++
++    return state->kaezip_ctx;
++}
++
++void setInflateKaezipCtx(z_streamp strm, unsigned long kaezip_ctx)
++{
++    struct inflate_state FAR *state;
++    
++    if (strm == Z_NULL) {
++        return;
++    }
++    state = (struct inflate_state FAR *)strm->state;
++
++    if (state == Z_NULL) {
++        return;
++    }
++
++    state->kaezip_ctx = kaezip_ctx;
++    return;
++}
++
+diff -Naru zlib-1.2.11/inflate.h ./zlib-1.2.11_new/inflate.h
+--- zlib-1.2.11/inflate.h	2017-01-01 15:37:10.000000000 +0800
++++ ./zlib-1.2.11_new/inflate.h	2020-09-17 11:41:29.474655410 +0800
+@@ -122,4 +122,5 @@
+     int sane;                   /* if false, allow invalid distance too far */
+     int back;                   /* bits back of last unprocessed length/lit */
+     unsigned was;               /* initial length of match */
++    unsigned long kaezip_ctx;   /* kunpeng kaezip context */
+ };
+diff -Naru zlib-1.2.11/Makefile.in ./zlib-1.2.11_new/Makefile.in
 --- zlib-1.2.11/Makefile.in	2017-01-16 01:29:40.000000000 +0800
-+++ zlib-1.2.11_new/Makefile.in	2020-06-06 18:50:13.720404200 +0800
++++ ./zlib-1.2.11_new/Makefile.in	2020-09-17 11:38:29.414655410 +0800
 @@ -26,7 +26,15 @@
  
  SFLAGS=-O

--- a/src/kaezip_common.c
+++ b/src/kaezip_common.c
@@ -27,9 +27,6 @@
 #include "wd.h"
 #include "wd_comp.h"
 
-#define WCRYPTO_NONE            (-1)
-#define WCRYPTO_RAW_DEFLATE     (2)
-
 #define __swab32(x)                \
       ((((x)&0x000000ff) << 24) |  \
         (((x)&0x0000ff00) << 8) |  \

--- a/src/kaezip_common.h
+++ b/src/kaezip_common.h
@@ -27,6 +27,9 @@
 #define KAEZIP_STREAM_CHUNK_IN         ((COMP_BLOCK_SIZE) >> 3)  // change the input size would change the performace
 #define KAEZIP_STREAM_CHUNK_OUT        (COMP_BLOCK_SIZE)
 
+#define WCRYPTO_NONE            (-1)
+#define WCRYPTO_RAW_DEFLATE     2
+
 int kz_get_devices(void);
 int kaezip_winbits2algtype(int windowBits);
 

--- a/src/kaezip_deflate.h
+++ b/src/kaezip_deflate.h
@@ -27,11 +27,15 @@ extern int kz_deflateInit2_(z_streamp strm, int level, int metho, int windowBit,
                       const char *version, int stream_size);
 extern int kz_deflate(z_streamp strm, int flush);
 extern int kz_deflateEnd(z_streamp strm);
+extern int kz_deflateReset(z_streamp strm);
 
 extern int lz_deflateEnd(z_streamp strm);
 extern int lz_deflateInit2_(z_streamp strm, int level, int metho, int windowBit, int memLevel, int strategy,
                       const char *version, int stream_size);
+extern int lz_deflateReset(z_streamp strm);
 
+extern unsigned long getDeflateKaezipCtx(z_streamp strm);
+extern void setDeflateKaezipCtx(z_streamp strm, unsigned long kaezip_ctx);
 #endif
 
 

--- a/src/kaezip_inflate.h
+++ b/src/kaezip_inflate.h
@@ -27,11 +27,15 @@ extern int kz_inflateInit2_(z_streamp strm, int windowBits, const char *version,
 extern int kz_inflate(z_streamp strm, int flush);
 extern int kz_inflateEnd(z_streamp strm);
 extern int kz_inflateReset(z_streamp strm);
+extern int kz_do_inflateInit(z_streamp strm, int alg_comp_type);
 
 extern int lz_inflateEnd(z_streamp strm);
 extern int lz_inflateInit2_(z_streamp strm, int windowBits, const char *version, int stream_size);
 extern int lz_inflateReset(z_streamp strm);
 
+extern int getInflateStateWrap(z_streamp strm);
+extern unsigned long getInflateKaezipCtx(z_streamp strm);
+extern void setInflateKaezipCtx(z_streamp strm, unsigned long kaezip_ctx);
 #endif
 
 


### PR DESCRIPTION
1. the context of KAEzip is used in the reserved bit of the external structure z_stream,which has risks
2. support KAEzip inflate with windowsBits is greater than 31.
3. Bugfix for KAEzip deflate reset issue.