### PR TITLE
fix bug and update kae version to 1.3.10

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ ENGINE_INSTALL_PATH := /usr/local/kaezip
 CC=gcc
 
 LIBNAME := libkaezip.so
-VERSION = 1.3.9
+VERSION = 1.3.10
 TARGET = ${LIBNAME}.${VERSION}
 SOFTLINK = libkaezip.so
 

--- a/include/kaezip.h
+++ b/include/kaezip.h
@@ -33,7 +33,7 @@ extern int kz_deflateInit2_(z_streamp strm, int level, int metho, int windowBit,
 extern int kz_inflateInit2_(z_streamp strm, int windowBits, const char *version, int stream_size);
 extern int kz_deflateEnd(z_streamp strm);
 extern int kz_inflateReset(z_streamp strm);
-extern int Kz_deflateReset(z_streamp strm);
+extern int kz_deflateReset(z_streamp strm);
 extern int kz_getAutoInflateAlgType(z_streamp strm);
 extern int kz_do_inflateInit(z_streamp strm, int alg_comp_type);
 

--- a/kaezip.spec
+++ b/kaezip.spec
@@ -1,6 +1,6 @@
 Name:          libkaezip
 Summary:       Huawei Kunpeng Accelerator Engine Zip
-Version:       1.3.9
+Version:       1.3.10
 Release:       1%dist
 License:       Apache-2.0
 Source:        %{name}-%{version}.tar.gz

--- a/src/kaezip_common.c
+++ b/src/kaezip_common.c
@@ -56,7 +56,7 @@ int kz_get_devices(void)
         return 1;
     }
 
-    kae_debug_init_log();
+    kaezip_debug_init_log();
     uacce_dev = opendir("/sys/class/uacce");
     if (!uacce_dev) {
         US_WARN("No /sys/class/uacce directory or it cannot be opened");

--- a/src/kaezip_conf.c
+++ b/src/kaezip_conf.c
@@ -22,7 +22,7 @@
 
 #include "kaezip_conf.h"
 
-int kae_drv_findsection(FILE *stream, const char *v_pszSection)
+int kaezip_drv_findsection(FILE *stream, const char *v_pszSection)
 {
     char line[256]; // array length:256
     char *pos = NULL;
@@ -49,7 +49,7 @@ int kae_drv_findsection(FILE *stream, const char *v_pszSection)
     return -1;
 }
 
-void kae_drv_get_value(char *pos, char *v_pszValue)
+void kaezip_drv_get_value(char *pos, char *v_pszValue)
 {
     while (*pos != '\0') {
         if (*pos == ' ') {
@@ -66,7 +66,7 @@ void kae_drv_get_value(char *pos, char *v_pszValue)
     }
 }
 
-int kae_drv_find_item(FILE *stream, const char *v_pszItem, char *v_pszValue)
+int kaezip_drv_find_item(FILE *stream, const char *v_pszItem, char *v_pszValue)
 {
     char line[256]; // array length:256
     char *pos = NULL;
@@ -80,7 +80,7 @@ int kae_drv_find_item(FILE *stream, const char *v_pszItem, char *v_pszValue)
             pos = strstr(line, "=");
             if (pos != NULL) {
                 pos++;
-                kae_drv_get_value(pos, v_pszValue);
+                kaezip_drv_get_value(pos, v_pszValue);
                 return 0;
             }
         }
@@ -93,7 +93,7 @@ int kae_drv_find_item(FILE *stream, const char *v_pszItem, char *v_pszValue)
     return -1;
 }
 
-int kae_drv_get_item(const char *config_file, const char *v_pszSection, 
+int kaezip_drv_get_item(const char *config_file, const char *v_pszSection, 
                      const char *v_pszItem, char *v_pszValue)
 {
     FILE *stream;
@@ -104,8 +104,8 @@ int kae_drv_get_item(const char *config_file, const char *v_pszSection,
         return -1;
     }
 
-    if (kae_drv_findsection(stream, v_pszSection) == 0) {
-        retvalue = kae_drv_find_item(stream, v_pszItem, v_pszValue);
+    if (kaezip_drv_findsection(stream, v_pszSection) == 0) {
+        retvalue = kaezip_drv_find_item(stream, v_pszItem, v_pszValue);
     }
 
     fclose(stream);

--- a/src/kaezip_conf.h
+++ b/src/kaezip_conf.h
@@ -27,7 +27,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-int kae_drv_get_item(const char *config_file, const char *v_pszSection, 
+int kaezip_drv_get_item(const char *config_file, const char *v_pszSection, 
                      const char *v_pszItem, char *v_pszValue);
 
 #endif  // HISI_ACC_OPENSSL_CONFIG_H

--- a/src/kaezip_log.h
+++ b/src/kaezip_log.h
@@ -28,15 +28,14 @@
 #include <time.h>
 #include <pthread.h>
 
-#define LOG_LEVEL_CONFIG      KAE_NONE
-#define KAE_DEBUG_FILE_PATH   "/var/log/kaezip.log"
-#define KAE_DEBUG_FILE_PATH_OLD "/var/log/kaezip.log.old"
+#define KAEZIP_DEBUG_FILE_PATH   "/var/log/kaezip.log"
+#define KAEZIP_DEBUG_FILE_PATH_OLD "/var/log/kaezip.log.old"
 #define KAE_LOG_MAX_SIZE 209715200
 
-extern FILE *g_kae_debug_log_file;
-extern pthread_mutex_t g_debug_file_mutex;
-extern const char *g_log_level[];
-extern int g_kae_log_level;
+extern FILE *g_kaezip_debug_log_file;
+extern pthread_mutex_t g_kaezip_debug_file_mutex;
+extern const char *g_kaezip_log_level_string[];
+extern int g_kaezip_log_level;
 
 enum KAE_LOG_LEVEL {
     KAE_NONE = 0,
@@ -48,46 +47,42 @@ enum KAE_LOG_LEVEL {
 
 void ENGINE_LOG_LIMIT(int level, int times, int limit, const char *fmt, ...);
 
-#define CRYPTO(LEVEL, fmt, args...)                                                                     \
+#define KAEZIP_CRYPTO(LEVEL, fmt, args...)                                                                     \
     do {                                                                                                \
-        if (LEVEL > g_kae_log_level) {                                                                  \
+        if (LEVEL > g_kaezip_log_level) {                                                                  \
             break;                                                                                      \
         }                                                                                               \
         struct tm *log_tm_p = NULL;                                                                     \
         time_t timep = time((time_t *)NULL);                                                            \
         log_tm_p = localtime(&timep);                                                                   \
-        flock(g_kae_debug_log_file->_fileno, LOCK_EX);                                                  \
-        pthread_mutex_lock(&g_debug_file_mutex);                                                        \
-        fseek(g_kae_debug_log_file, 0, SEEK_END);                                                       \
+        flock(g_kaezip_debug_log_file->_fileno, LOCK_EX);                                                  \
+        pthread_mutex_lock(&g_kaezip_debug_file_mutex);                                                        \
+        fseek(g_kaezip_debug_log_file, 0, SEEK_END);                                                       \
         if (log_tm_p != NULL) {                                                                         \
-            fprintf(g_kae_debug_log_file, "[%4d-%02d-%02d %02d:%02d:%02d][%s][%s:%d:%s()] " fmt "\n",   \
+            fprintf(g_kaezip_debug_log_file, "[%4d-%02d-%02d %02d:%02d:%02d][%s][%s:%d:%s()] " fmt "\n",   \
                 (1900 + log_tm_p->tm_year), (1 + log_tm_p->tm_mon), log_tm_p->tm_mday,                  \
                 log_tm_p->tm_hour, log_tm_p->tm_min, log_tm_p->tm_sec,                                  \
-                g_log_level[LEVEL], __FILE__, __LINE__, __func__, ##args);                              \
+                g_kaezip_log_level_string[LEVEL], __FILE__, __LINE__, __func__, ##args);                              \
         } else {                                                                                        \
-            fprintf(g_kae_debug_log_file, "[%s][%s:%d:%s()] " fmt "\n",                                 \
-                g_log_level[LEVEL], __FILE__, __LINE__, __func__, ##args);                              \
+            fprintf(g_kaezip_debug_log_file, "[%s][%s:%d:%s()] " fmt "\n",                                 \
+                g_kaezip_log_level_string[LEVEL], __FILE__, __LINE__, __func__, ##args);                              \
         }                                                                                               \
-        if (ftell(g_kae_debug_log_file) > KAE_LOG_MAX_SIZE) {                                           \
-            kae_save_log(g_kae_debug_log_file);                                                         \
-            ftruncate(g_kae_debug_log_file->_fileno, 0);                                                \
-            fseek(g_kae_debug_log_file, 0, SEEK_SET);                                                   \
+        if (ftell(g_kaezip_debug_log_file) > KAE_LOG_MAX_SIZE) {                                           \
+            kaezip_save_log(g_kaezip_debug_log_file);                                                         \
+            ftruncate(g_kaezip_debug_log_file->_fileno, 0);                                                \
+            fseek(g_kaezip_debug_log_file, 0, SEEK_SET);                                                   \
         }                                                                                               \
-            pthread_mutex_unlock(&g_debug_file_mutex);                                                  \
-            flock(g_kae_debug_log_file->_fileno, LOCK_UN);                                              \
+            pthread_mutex_unlock(&g_kaezip_debug_file_mutex);                                                  \
+            flock(g_kaezip_debug_log_file->_fileno, LOCK_UN);                                              \
     } while (0)
 
-#define US_ERR(fmt, args...)          CRYPTO(KAE_ERROR, fmt, ##args)
-#define US_WARN(fmt, args...)         CRYPTO(KAE_WARNING, fmt, ##args)
-#define US_INFO(fmt, args...)         CRYPTO(KAE_INFO, fmt, ##args)
-#define US_DEBUG(fmt, args...)        CRYPTO(KAE_DEBUG, fmt, ##args)
-#define US_WARN_LIMIT(fmt, args...)   ENGINE_LOG_LIMIT(KAE_WARNING, 3, 30, fmt, ##args)
-#define US_ERR_LIMIT(fmt, args...)    ENGINE_LOG_LIMIT(KAE_ERROR, 3, 30, fmt, ##args)
-#define US_INFO_LIMIT(fmt, args...)   ENGINE_LOG_LIMIT(KAE_INFO, 3, 30, fmt, ##args)
-#define US_DEBUG_LIMIT(fmt, args...)  ENGINE_LOG_LIMIT(KAE_DEBUG, 3, 30, fmt, ##args)
+#define US_ERR(fmt, args...)          KAEZIP_CRYPTO(KAE_ERROR, fmt, ##args)
+#define US_WARN(fmt, args...)         KAEZIP_CRYPTO(KAE_WARNING, fmt, ##args)
+#define US_INFO(fmt, args...)         KAEZIP_CRYPTO(KAE_INFO, fmt, ##args)
+#define US_DEBUG(fmt, args...)        KAEZIP_CRYPTO(KAE_DEBUG, fmt, ##args)
 
-void kae_debug_init_log();
-void kae_debug_close_log();
-void kae_save_log(FILE *src);
+void kaezip_debug_init_log();
+void kaezip_debug_close_log();
+void kaezip_save_log(FILE *src);
 
 #endif

--- a/src/wd_queue_memory.c
+++ b/src/wd_queue_memory.c
@@ -25,11 +25,12 @@
 #include "kaezip_log.h"
 #include "wd_bmm.h"
 #include "wd_comp.h"
+#include "kaezip_ctx.h"
 
-void wd_free_queue(struct wd_queue* queue);
-struct wd_queue* wd_new_queue(int comp_alg_type, int comp_optype);
+void kaezip_wd_free_queue(struct wd_queue* queue);
+struct wd_queue* kaezip_wd_new_queue(int comp_alg_type, int comp_optype);
 
-struct wd_queue* wd_new_queue(int comp_alg_type, int comp_optype)
+struct wd_queue* kaezip_wd_new_queue(int comp_alg_type, int comp_optype)
 {
     struct wd_queue* queue = (struct wd_queue *)kae_malloc(sizeof(struct wd_queue));
     if (queue == NULL) {
@@ -65,7 +66,7 @@ struct wd_queue* wd_new_queue(int comp_alg_type, int comp_optype)
     return queue;
 }
 
-void wd_free_queue(struct wd_queue* queue)
+void kaezip_wd_free_queue(struct wd_queue* queue)
 {
     if (queue != NULL) {
         wd_release_queue(queue);
@@ -74,7 +75,7 @@ void wd_free_queue(struct wd_queue* queue)
     }
 }
 
-void* create_alg_wd_queue_mempool(struct wd_queue *q)
+void* kaezip_create_alg_wd_queue_mempool(struct wd_queue *q)
 {
     unsigned int block_size = COMP_BLOCK_SIZE;
     unsigned int block_num = COMP_BLOCK_NUM;
@@ -90,22 +91,22 @@ void* create_alg_wd_queue_mempool(struct wd_queue *q)
     return mempool;
 }
 
-void wd_queue_mempool_destroy(void *pool)
+void kaezip_wd_queue_mempool_destroy(void *pool)
 {
     return wd_blkpool_destroy(pool);
 }
 
-void *kae_dma_map(void *usr, void *va, size_t sz)
+void *kaezip_dma_map(void *usr, void *va, size_t sz)
 {
     return wd_blk_iova_map(usr, va);
 }
 
-void kae_dma_unmap(void *usr, void *va, void *dma, size_t sz)
+void kaezip_dma_unmap(void *usr, void *va, void *dma, size_t sz)
 {
     return wd_blk_iova_unmap(usr, dma, va);
 }
 
-void *kae_wd_alloc_blk(void *pool, size_t size)
+void *kaezip_wd_alloc_blk(void *pool, size_t size)
 {
     if (pool == NULL) {
         US_ERR("mem pool empty!");
@@ -115,12 +116,12 @@ void *kae_wd_alloc_blk(void *pool, size_t size)
     return wd_alloc_blk(pool);
 }
 
-void kae_wd_free_blk(void *pool, void *blk)
+void kaezip_wd_free_blk(void *pool, void *blk)
 {
     return wd_free_blk(pool, blk);
 }
 
-KAE_QUEUE_POOL_HEAD_S* kae_init_queue_pool(int algtype)
+KAE_QUEUE_POOL_HEAD_S* kaezip_init_queue_pool(int algtype)
 {
     KAE_QUEUE_POOL_HEAD_S *kae_pool = NULL;
 
@@ -151,7 +152,7 @@ KAE_QUEUE_POOL_HEAD_S* kae_init_queue_pool(int algtype)
     return kae_pool;
 }
 
-static KAE_QUEUE_DATA_NODE_S* kae_get_queue_data_from_list(KAE_QUEUE_POOL_HEAD_S* pool_head, int type)
+static KAE_QUEUE_DATA_NODE_S* kaezip_get_queue_data_from_list(KAE_QUEUE_POOL_HEAD_S* pool_head, int type)
 {
     int i = 0;
     KAE_QUEUE_DATA_NODE_S *queue_data_node = NULL;
@@ -193,7 +194,7 @@ static KAE_QUEUE_DATA_NODE_S* kae_get_queue_data_from_list(KAE_QUEUE_POOL_HEAD_S
     return queue_data_node;
 }
 
-static void kae_free_wd_queue_memory(KAE_QUEUE_DATA_NODE_S *queue_node, kae_release_priv_ctx_cb release_fn)
+static void kaezip_free_wd_queue_memory(KAE_QUEUE_DATA_NODE_S *queue_node, kae_release_priv_ctx_cb release_fn)
 {
     if (queue_node != NULL) {
         if (release_fn != NULL && queue_node->priv_ctx != NULL) {
@@ -202,11 +203,11 @@ static void kae_free_wd_queue_memory(KAE_QUEUE_DATA_NODE_S *queue_node, kae_rele
         }
 
         if (queue_node->kae_queue_mem_pool != NULL) {
-            wd_queue_mempool_destroy(queue_node->kae_queue_mem_pool);
+            kaezip_wd_queue_mempool_destroy(queue_node->kae_queue_mem_pool);
             queue_node->kae_queue_mem_pool = NULL;
         }
         if (queue_node->kae_wd_queue != NULL) {
-            wd_free_queue(queue_node->kae_wd_queue);
+            kaezip_wd_free_queue(queue_node->kae_wd_queue);
             queue_node->kae_wd_queue = NULL;
         }
         
@@ -217,7 +218,7 @@ static void kae_free_wd_queue_memory(KAE_QUEUE_DATA_NODE_S *queue_node, kae_rele
     US_DEBUG("free wd queue success");
 }
 
-static KAE_QUEUE_DATA_NODE_S* kae_new_wd_queue_memory(int comp_alg_type, int comp_type)
+static KAE_QUEUE_DATA_NODE_S* kaezip_new_wd_queue_memory(int comp_alg_type, int comp_type)
 {
     KAE_QUEUE_DATA_NODE_S *queue_node = NULL;
     
@@ -228,13 +229,13 @@ static KAE_QUEUE_DATA_NODE_S* kae_new_wd_queue_memory(int comp_alg_type, int com
     }
     memset(queue_node, 0, sizeof(KAE_QUEUE_DATA_NODE_S));
     
-    queue_node->kae_wd_queue = wd_new_queue(comp_alg_type, comp_type);
+    queue_node->kae_wd_queue = kaezip_wd_new_queue(comp_alg_type, comp_type);
     if (queue_node->kae_wd_queue == NULL) {
         US_ERR("new wd queue fail");
         goto err;
     }
     
-    queue_node->kae_queue_mem_pool = create_alg_wd_queue_mempool(queue_node->kae_wd_queue);
+    queue_node->kae_queue_mem_pool = kaezip_create_alg_wd_queue_mempool(queue_node->kae_wd_queue);
     if (queue_node->kae_queue_mem_pool == NULL) {
         US_ERR("request mempool fail!");
         goto err;
@@ -244,11 +245,11 @@ static KAE_QUEUE_DATA_NODE_S* kae_new_wd_queue_memory(int comp_alg_type, int com
     return queue_node;
     
 err:
-    kae_free_wd_queue_memory(queue_node, NULL);
+    kaezip_free_wd_queue_memory(queue_node, NULL);
     return NULL;
 }
 
-KAE_QUEUE_DATA_NODE_S* kae_get_node_from_pool(KAE_QUEUE_POOL_HEAD_S* pool_head, int comp_alg_type, int comp_type)
+KAE_QUEUE_DATA_NODE_S* kaezip_get_node_from_pool(KAE_QUEUE_POOL_HEAD_S* pool_head, int comp_alg_type, int comp_type)
 {
     KAE_QUEUE_DATA_NODE_S *queue_data_node = NULL;
 
@@ -257,15 +258,15 @@ KAE_QUEUE_DATA_NODE_S* kae_get_node_from_pool(KAE_QUEUE_POOL_HEAD_S* pool_head, 
         return NULL;
     }
 
-    queue_data_node = kae_get_queue_data_from_list(pool_head, comp_alg_type);
+    queue_data_node = kaezip_get_queue_data_from_list(pool_head, comp_alg_type);
     if (queue_data_node == NULL) {
-        queue_data_node = kae_new_wd_queue_memory(comp_alg_type, comp_type);
+        queue_data_node = kaezip_new_wd_queue_memory(comp_alg_type, comp_type);
     }
 
     return queue_data_node;
 }
 
-static void kae_set_pool_use_num(KAE_QUEUE_POOL_HEAD_S *pool, int set_num)
+static void kaezip_set_pool_use_num(KAE_QUEUE_POOL_HEAD_S *pool, int set_num)
 {
     pthread_mutex_lock(&pool->kae_queue_mutex);
     if (set_num > pool->pool_use_num) {
@@ -274,7 +275,7 @@ static void kae_set_pool_use_num(KAE_QUEUE_POOL_HEAD_S *pool, int set_num)
     (void)pthread_mutex_unlock(&pool->kae_queue_mutex);
 }
 
-int kae_put_node_to_pool(KAE_QUEUE_POOL_HEAD_S* pool_head,  KAE_QUEUE_DATA_NODE_S* node_data)
+int kaezip_put_node_to_pool(KAE_QUEUE_POOL_HEAD_S* pool_head,  KAE_QUEUE_DATA_NODE_S* node_data)
 {
     int i = 0;
     KAE_QUEUE_POOL_HEAD_S *temp_pool = pool_head;
@@ -299,7 +300,7 @@ int kae_put_node_to_pool(KAE_QUEUE_POOL_HEAD_S* pool_head,  KAE_QUEUE_DATA_NODE_
                     temp_pool->kae_queue_pool[i].add_time = time((time_t *)NULL);
                     KAE_SPIN_UNLOCK(temp_pool->kae_queue_pool[i].spinlock);
                     if (i >= temp_pool->pool_use_num) {
-                        kae_set_pool_use_num(temp_pool, i + 1);
+                        kaezip_set_pool_use_num(temp_pool, i + 1);
                     }
     
                     US_DEBUG("kaezip put queue node to pool, queue node id is %d.", i);
@@ -313,7 +314,7 @@ int kae_put_node_to_pool(KAE_QUEUE_POOL_HEAD_S* pool_head,  KAE_QUEUE_DATA_NODE_
         if (temp_pool == NULL) {
             pthread_mutex_lock(&last_pool->destroy_mutex);
             if (last_pool->next == NULL) {
-                temp_pool = kae_init_queue_pool(last_pool->algtype);
+                temp_pool = kaezip_init_queue_pool(last_pool->algtype);
                 if (temp_pool == NULL) {
                     (void)pthread_mutex_unlock(&last_pool->destroy_mutex);
                     break;
@@ -324,17 +325,17 @@ int kae_put_node_to_pool(KAE_QUEUE_POOL_HEAD_S* pool_head,  KAE_QUEUE_DATA_NODE_
         }
     }
     /* if not added,free it */    
-    kae_free_wd_queue_memory(node_data, NULL);
+    kaezip_free_wd_queue_memory(node_data, kaezip_free_ctx);
     return 0;
 }
 
-void kae_queue_pool_reset(KAE_QUEUE_POOL_HEAD_S* pool_head)
+void kaezip_queue_pool_reset(KAE_QUEUE_POOL_HEAD_S* pool_head)
 {
     (void)pool_head;
     return;
 }
 
-void kae_queue_pool_destroy(KAE_QUEUE_POOL_HEAD_S* pool_head, kae_release_priv_ctx_cb release_fn)
+void kaezip_queue_pool_destroy(KAE_QUEUE_POOL_HEAD_S* pool_head, kae_release_priv_ctx_cb release_fn)
 {
     int error = 0;
     int i = 0;
@@ -357,7 +358,7 @@ void kae_queue_pool_destroy(KAE_QUEUE_POOL_HEAD_S* pool_head, kae_release_priv_c
         for (i = 0; i < cur_pool->pool_use_num; i++) {
             queue_data_node = cur_pool->kae_queue_pool[i].node_data;
             if (queue_data_node != NULL) {
-                kae_free_wd_queue_memory(queue_data_node, release_fn);
+                kaezip_free_wd_queue_memory(queue_data_node, release_fn);
                 US_DEBUG("kae queue node destroy success. queue_node id =%d", i);
                 cur_pool->kae_queue_pool[i].node_data = NULL;
             }
@@ -382,7 +383,7 @@ void kae_queue_pool_destroy(KAE_QUEUE_POOL_HEAD_S* pool_head, kae_release_priv_c
     return;
 }
 
-void kae_queue_pool_check_and_release(KAE_QUEUE_POOL_HEAD_S* pool_head, kae_release_priv_ctx_cb release_fn)
+void kaezip_queue_pool_check_and_release(KAE_QUEUE_POOL_HEAD_S* pool_head, kae_release_priv_ctx_cb release_fn)
 {
     int i = 0;
     int error;
@@ -424,7 +425,7 @@ void kae_queue_pool_check_and_release(KAE_QUEUE_POOL_HEAD_S* pool_head, kae_rele
                     cur_pool->kae_queue_pool[i].node_data = (KAE_QUEUE_DATA_NODE_S *)NULL;
                     KAE_SPIN_UNLOCK(cur_pool->kae_queue_pool[i].spinlock);
 
-                    kae_free_wd_queue_memory(queue_data_node, release_fn);
+                    kaezip_free_wd_queue_memory(queue_data_node, release_fn);
 
                     US_DEBUG("hpre queue list release success. queue node id =%d", i);
                 }

--- a/src/wd_queue_memory.h
+++ b/src/wd_queue_memory.h
@@ -61,17 +61,17 @@ typedef struct KAE_QUEUE_POOL_HEAD {
     KAE_QUEUE_POOL_NODE_S *kae_queue_pool; /* point to a attray */
 } KAE_QUEUE_POOL_HEAD_S;
 
-void kae_wd_free_blk(void *pool, void *blk);
-void *kae_wd_alloc_blk(void *pool, size_t size);
-void *kae_dma_map(void *usr, void *va, size_t sz);
-void kae_dma_unmap(void *usr, void *va, void *dma, size_t sz);
+void kaezip_wd_free_blk(void *pool, void *blk);
+void *kaezip_wd_alloc_blk(void *pool, size_t size);
+void *kaezip_dma_map(void *usr, void *va, size_t sz);
+void kaezip_dma_unmap(void *usr, void *va, void *dma, size_t sz);
 
-KAE_QUEUE_POOL_HEAD_S* kae_init_queue_pool (int algtype);
-KAE_QUEUE_DATA_NODE_S* kae_get_node_from_pool(KAE_QUEUE_POOL_HEAD_S* pool_head, int alg_comp_type, int comp_optype);
-int kae_put_node_to_pool (KAE_QUEUE_POOL_HEAD_S* pool_head, KAE_QUEUE_DATA_NODE_S* node_data);
-void kae_queue_pool_reset(KAE_QUEUE_POOL_HEAD_S* pool_head);
-void kae_queue_pool_destroy(KAE_QUEUE_POOL_HEAD_S* pool_head, kae_release_priv_ctx_cb release_fn);
-void kae_queue_pool_check_and_release(KAE_QUEUE_POOL_HEAD_S* pool_head, kae_release_priv_ctx_cb release_ectx_fn);
+KAE_QUEUE_POOL_HEAD_S* kaezip_init_queue_pool (int algtype);
+KAE_QUEUE_DATA_NODE_S* kaezip_get_node_from_pool(KAE_QUEUE_POOL_HEAD_S* pool_head, int alg_comp_type, int comp_optype);
+int kaezip_put_node_to_pool (KAE_QUEUE_POOL_HEAD_S* pool_head, KAE_QUEUE_DATA_NODE_S* node_data);
+void kaezip_queue_pool_reset(KAE_QUEUE_POOL_HEAD_S* pool_head);
+void kaezip_queue_pool_destroy(KAE_QUEUE_POOL_HEAD_S* pool_head, kae_release_priv_ctx_cb release_fn);
+void kaezip_queue_pool_check_and_release(KAE_QUEUE_POOL_HEAD_S* pool_head, kae_release_priv_ctx_cb release_ectx_fn);
 
 #endif
 


### PR DESCRIPTION
1. change the variables and interface names in the module to kaezip.
2. fix hardware queues lost problem when multiple threads concurrency.
3. update kae version to 1.3.10